### PR TITLE
Add Sidebar class only if needed for J3

### DIFF
--- a/src/include.php
+++ b/src/include.php
@@ -44,7 +44,9 @@ if (!defined('ALLEDIA_FRAMEWORK_LOADED')) {
 
     if (Version::MAJOR_VERSION < 4) {
         // Add some shims for Joomla 3
-        class_alias('JHtmlSidebar', '\\Joomla\\CMS\\HTML\\Helpers\\Sidebar');
+        if (!class_exists('\\Joomla\\CMS\\HTML\\Helpers\\Sidebar')) {
+            class_alias('JHtmlSidebar', '\\Joomla\\CMS\\HTML\\Helpers\\Sidebar');
+        }
     }
 }
 


### PR DESCRIPTION
Because of:
PHP Warning:  Cannot declare class \Joomla\CMS\HTML\Helpers\Sidebar, because the name is already in use in /home/public_html/libraries/allediaframework/include.php on line 47